### PR TITLE
Fixes the port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN set -x \
 ENV PATH $PATH:/opt/elixir-${ELIXIR_VERSION}/bin
 
 ENV MIX_ENV prod
-ENV PORT 8080
+ENV PORT 3008
 EXPOSE $PORT
 
 COPY . /src


### PR DESCRIPTION
- We standardized on using port 3008 for poxa
- During a rebase this was reverted to port 8080 by accident
- connect waffleio/waffle.io-takeout#190
